### PR TITLE
added workflow_dispatch option for docker build

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -6,6 +6,7 @@
 name: docker-publish-release
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 


### PR DESCRIPTION
When the Paramak is updated the docker image becomes out of date.

We don't want to create a release (which would trigger a docker image rebuild) as the paramak-neutronics source code has not changed.

So this PR adds the ability to perform a manual triggering of the docker building and publishing github action.