### PR TITLE
no longer warning when file not found

### DIFF
--- a/paramak_neutronics/__init__.py
+++ b/paramak_neutronics/__init__.py
@@ -4,5 +4,6 @@ from .neutronics_utils import find_material_groups_in_h5m
 from .neutronics_utils import find_volume_ids_in_h5m
 from .neutronics_utils import create_inital_particles
 from .neutronics_utils import extract_points_from_initial_source
+from .neutronics_utils import silently_remove_file
 
 from .neutronics_model import NeutronicsModel

--- a/paramak_neutronics/neutronics_model.py
+++ b/paramak_neutronics/neutronics_model.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple, Union
 import paramak
 from .neutronics_utils import get_neutronics_results_from_statepoint_file
 from .neutronics_utils import (create_inital_particles,
+                               silently_remove_file,
                                extract_points_from_initial_source)
 from paramak.utils import plotly_trace
 
@@ -287,7 +288,7 @@ class NeutronicsModel():
         #             "material has been added that is not needed for this \
         #             reactor model", reactor_material)
 
-        os.system('rm materials.xml')
+        silently_remove_file('materials.xml')
 
         openmc_materials = {}
         for material_tag, material_entry in self.materials.items():
@@ -395,9 +396,9 @@ class NeutronicsModel():
             mesh_3d_corners = self.mesh_3d_corners
 
         # this removes any old file from previous simulations
-        os.system('rm geometry.xml')
-        os.system('rm settings.xml')
-        os.system('rm tallies.xml')
+        silently_remove_file('geometry.xml')
+        silently_remove_file('settings.xml')
+        silently_remove_file('tallies.xml')
 
         # materials.xml is removed in this function
         self.create_openmc_materials()
@@ -641,7 +642,7 @@ class NeutronicsModel():
             self.export_xml()
 
         if export_h5m is True:
-            os.system('rm *.h5')
+            silently_remove_file('dagmc.h5')
             self.geometry.export_h5m()
 
         # checks all the nessecary files are found
@@ -661,8 +662,8 @@ class NeutronicsModel():
 
         # Deletes summary.h5m if it already exists.
         # This avoids permission problems when trying to overwrite the file
-        os.system('rm summary.h5')
-        os.system('rm statepoint.' + str(self.simulation_batches) + '.h5')
+        silently_remove_file('summary.h5')
+        silently_remove_file('statepoint.' + str(self.simulation_batches) + '.h5')
 
         self.statepoint_filename = self.model.run(
             output=verbose, threads=threads

--- a/paramak_neutronics/neutronics_utils.py
+++ b/paramak_neutronics/neutronics_utils.py
@@ -1,6 +1,7 @@
 
 import math
 import os
+import errno
 import subprocess
 import warnings
 from collections import defaultdict
@@ -17,6 +18,16 @@ try:
 except ImportError:
     warnings.warn('OpenMC not found, create_inital_particles \
             method not available', UserWarning)
+
+
+def silently_remove_file(filename: str):
+    """Allows files to be deleted without printing warning messages int the 
+    terminal. input XML files for OpenMC are deleted prior to running
+    simulations and many not exist."""
+    try:
+        os.remove(filename)
+    except OSError:
+        pass  # in some cases the file will not exist
 
 
 def find_volume_ids_in_h5m(
@@ -468,7 +479,11 @@ def create_inital_particles(
 
     model = openmc.model.Model(geom, mats, sett)
 
-    os.system('rm *.xml')
+    silently_remove_file('settings.xml')
+    silently_remove_file('materials.xml')
+    silently_remove_file('geometry.xml')
+    silently_remove_file('settings.xml')
+    silently_remove_file('tallies.xml')
     model.export_to_xml()
 
     # this just adds write_initial_source == True to the settings.xml


### PR DESCRIPTION
Currently lots of warnings are printed when we try to delete a file using ```os.system('rm filename')```

This introduces a method that silently fails when the file is not found.

If the file is not found for deletion then this is not a problem to concern the user with