### PR TITLE
Changing trelis to cubit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,17 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# output files from simulations
+*.png
+*.vtk
+*.jou
+*.cub
+*.json
+*.xml
+*.h5
+*.h5m
+*.stl
+*.stp
+*.trelis
+*.out

--- a/examples/ball_reactor.ipynb
+++ b/examples/ball_reactor.ipynb
@@ -2,16 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "This example makes a reactor geometry and a neutronics model. A homogenised material made of enriched lithium lead and eurofer is being used as the blanket material for this simulation in order to demonstrate the use of more complex materials."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import neutronics_material_maker as nmm\n",
     "import openmc\n",
@@ -33,12 +31,12 @@
     "    elongation=2.75,\n",
     "    triangularity=0.5,\n",
     "    number_of_tf_coils=16,\n",
-    "    rotation_angle=359.9,  # when using trelis method this can be set to 360\n",
+    "    rotation_angle=359.9,  # when using Cubit method this can be set to 360\n",
     ")\n",
     "\n",
-    "# method is set to Trelis or Cubit by default to avoid overlaps in the geometry\n",
+    "# method is set to Cubit or Cubit by default to avoid overlaps in the geometry\n",
     "# pymoab is used as it is open source and can be tested in the CI\n",
-    "# if you have Trelis or Cubit then this line can be deleted\n",
+    "# if you have Cubit or Cubit then this line can be deleted\n",
     "my_reactor.method='pymoab'\n",
     "\n",
     "# makes a homogenised material for the blanket from lithium lead and\n",
@@ -82,7 +80,9 @@
     "\n",
     "# prints the results to screen\n",
     "print('TBR', neutronics_model.results['TBR'])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/ball_reactor_minimal.ipynb
+++ b/examples/ball_reactor_minimal.ipynb
@@ -2,16 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "This is a minimal example that obtains the TBR (Tritium Breeding Ratio) for a parametric ball reactor"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import openmc\n",
     "import paramak\n",
@@ -33,12 +31,12 @@
     "    elongation=2,\n",
     "    triangularity=0.55,\n",
     "    number_of_tf_coils=16,\n",
-    "    rotation_angle=359.9,  # when using trelis method this can be set to 360\n",
+    "    rotation_angle=359.9,  # when using Cubit method this can be set to 360\n",
     ")\n",
     "\n",
-    "# method is set to Trelis or Cubit by default to avoid overlaps in the geometry\n",
+    "# method is set to Cubit or Cubit by default to avoid overlaps in the geometry\n",
     "# pymoab is used as it is open source and can be tested in the CI\n",
-    "# if you have Trelis or Cubit then this line can be deleted\n",
+    "# if you have Cubit then this line can be deleted\n",
     "my_reactor.method='pymoab'\n",
     "\n",
     "source = openmc.Source()\n",
@@ -68,14 +66,16 @@
     "# simulate the neutronics model\n",
     "neutronics_model.simulate()\n",
     "print(neutronics_model.results)\n"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/heating_on_unstructured_mesh_shape.py
+++ b/examples/heating_on_unstructured_mesh_shape.py
@@ -4,7 +4,7 @@ import paramak
 
 rotated_spline = paramak.RotateSplineShape(
     rotation_angle=180,
-    method='trelis',
+    method='cubit',
     points=[
         (500, 0),
         (500, -20),

--- a/tests/test_NeutronicModel.py
+++ b/tests/test_NeutronicModel.py
@@ -602,15 +602,15 @@ class TestShape(unittest.TestCase):
         assert Path("flux_on_2D_mesh_xy.png").exists() is True
         assert Path("flux_on_2D_mesh_yz.png").exists() is True
 
-    def test_trelis_run_without_trelis(self):
+    def test_cubit_run_without_cubit(self):
         """Creates NeutronicsModel objects and checks errors are
         raised correctly when arguments are incorrect."""
 
-        # If Trelis is in the CI then this should work
+        # If cubit is in the CI then this should work
         def test_export_h5m_error_handling():
             """Makes a reactor from two shapes, then mades a neutronics model
             and tests the TBR simulation value"""
-            self.my_shape.method = 'trelis'
+            self.my_shape.method = 'cubit'
             paramak_neutronics.NeutronicsModel(
                 geometry=self.my_shape,
                 source=self.source,


### PR DESCRIPTION
This PR renames trelis to cubit across most of the package.

The one exception is the exporting of a "trelis" file from the make faceted geometry. This needs further checking to see what the new equivalent is