### PR TITLE
Using bounding box for mesh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: run test_NeutronicModel
           command: 
-            pytest tests/test_neutronic_model.py -v --cov=paramak_neutronics --cov-append --cov-report term --cov-report xml
+            pytest tests/test_neutronics_model.py -v --cov=paramak_neutronics --cov-append --cov-report term --cov-report xml
 
       - run:
           name: run test_shape_neutronics

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,9 +126,9 @@ RUN git clone --shallow-submodules --single-branch --branch main --depth 1 https
 # Clone and install DAGMC
 RUN mkdir DAGMC && \
     cd DAGMC && \
-    # git clone --single-branch --branch 3.2.0 --depth 1 https://github.com/svalinn/DAGMC.git && \
-    # git clone --shallow-submodules --single-branch --branch develop --depth 1 https://github.com/svalinn/DAGMC.git && \
-    git clone --shallow-submodules --single-branch --branch dd_bbox --depth 1 https://github.com/pshriwise/DAGMC.git && \
+    # change to version 3.2.1 when released
+    # git clone --single-branch --branch 3.2.1 --depth 1 https://github.com/svalinn/DAGMC.git && \
+    git clone --shallow-submodules --single-branch --branch develop --depth 1 https://github.com/svalinn/DAGMC.git && \
     mkdir build && \
     cd build && \
     cmake ../DAGMC -DBUILD_TALLY=ON \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ RUN conda install -c conda-forge -c python python=3.8 && \
 RUN apt-get install -y \
     wget \
     git \
-    gfortran g++ cmake \
+    gfortran \
+    g++ \
+    cmake \
     mpich \
     libmpich-dev \
     libhdf5-serial-dev \

--- a/examples/component_based_mesh_simulation.py
+++ b/examples/component_based_mesh_simulation.py
@@ -15,11 +15,11 @@ def main():
         inner_radius=50,
         mid_radius=70,
         outer_radius=100,
-        material_tag='center_column_shield_mat',
-        method='pymoab',
+        material_tag="center_column_shield_mat",
+        method="pymoab",
     )
 
-    my_shape.export_stp('my_shape.stp')
+    my_shape.export_stp("my_shape.stp")
 
     # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
     # diections
@@ -31,10 +31,10 @@ def main():
     my_model = paramak.NeutronicsModel(
         h5m_filename=my_shape.export_h5m(),
         source=source,
-        materials={'center_column_shield_mat': 'WB'},  # WB is tungsten boride
-        cell_tallies=['heating', 'TBR'],
-        mesh_tally_2d=['heating'],
-        mesh_tally_3d=['heating'],
+        materials={"center_column_shield_mat": "WB"},  # WB is tungsten boride
+        cell_tallies=["heating", "TBR"],
+        mesh_tally_2d=["heating"],
+        mesh_tally_3d=["heating"],
         simulation_batches=10,  # should be increased for more accurate result
         simulation_particles_per_batch=10,  # settings are low to reduce time required
     )

--- a/examples/segmented_blanket_ball_reactor.py
+++ b/examples/segmented_blanket_ball_reactor.py
@@ -38,7 +38,7 @@ def make_model_and_simulate():
             firstwall_structural_fraction,
             firstwall_armour_fraction,
         ],
-        percent_type="vo"
+        percent_type="vo",
     )
 
     # based on
@@ -59,14 +59,14 @@ def make_model_and_simulate():
                 temperature=blanket_rear_wall_coolant_temperature,
                 pressure=blanket_rear_wall_coolant_pressure,
             ),
-            nmm.Material.from_library(
-                name=blanket_rear_wall_structural_material),
+            nmm.Material.from_library(name=blanket_rear_wall_structural_material),
         ],
         fracs=[
             blanket_rear_wall_coolant_fraction,
             blanket_rear_wall_structural_fraction,
         ],
-        percent_type="vo")
+        percent_type="vo",
+    )
 
     # based on
     # https://www.sciencedirect.com/science/article/pii/S2352179118300437
@@ -113,7 +113,7 @@ def make_model_and_simulate():
             blanket_multiplier_fraction,
             blanket_breeder_fraction,
         ],
-        percent_type="vo"
+        percent_type="vo",
     )
 
     # based on
@@ -136,7 +136,7 @@ def make_model_and_simulate():
             nmm.Material.from_library(name=divertor_structural_material),
         ],
         fracs=[divertor_coolant_fraction, divertor_structural_fraction],
-        percent_type="vo"
+        percent_type="vo",
     )
 
     # based on
@@ -156,14 +156,14 @@ def make_model_and_simulate():
                 temperature=center_column_shield_coolant_temperature_k,
                 pressure=center_column_shield_coolant_pressure_Pa,
             ),
-            nmm.Material.from_library(
-                name=center_column_shield_structural_material),
+            nmm.Material.from_library(name=center_column_shield_structural_material),
         ],
         fracs=[
             center_column_shield_coolant_fraction,
             center_column_shield_structural_fraction,
         ],
-        percent_type="vo")
+        percent_type="vo",
+    )
 
     # based on
     # https://pdfs.semanticscholar.org/95fa/4dae7d82af89adf711b97e75a241051c7129.pdf
@@ -184,17 +184,16 @@ def make_model_and_simulate():
                 temperature=inboard_tf_coils_coolant_temperature_k,
                 pressure=inboard_tf_coils_coolant_pressure_Pa,
             ),
-            nmm.Material.from_library(
-                name=inboard_tf_coils_conductor_material),
-            nmm.Material.from_library(
-                name=inboard_tf_coils_structure_material),
+            nmm.Material.from_library(name=inboard_tf_coils_conductor_material),
+            nmm.Material.from_library(name=inboard_tf_coils_structure_material),
         ],
         fracs=[
             inboard_tf_coils_coolant_fraction,
             inboard_tf_coils_conductor_fraction,
             inboard_tf_coils_structure_fraction,
         ],
-        percent_type="vo")
+        percent_type="vo",
+    )
 
     # makes the 3d geometry
     my_reactor = paramak.BallReactor(
@@ -228,13 +227,14 @@ def make_model_and_simulate():
         h5m_filename=my_reactor.export_h5m(),
         source=source,
         materials={
-            'inboard_tf_coils_mat': inboard_tf_coils_material,
-            'center_column_shield_mat': center_column_shield_material,
-            'divertor_mat': divertor_material,
-            'firstwall_mat': firstwall_material,
-            'blanket_mat': blanket_material,
-            'blanket_rear_wall_mat': blanket_rear_wall_material},
-        cell_tallies=['TBR'],
+            "inboard_tf_coils_mat": inboard_tf_coils_material,
+            "center_column_shield_mat": center_column_shield_material,
+            "divertor_mat": divertor_material,
+            "firstwall_mat": firstwall_material,
+            "blanket_mat": blanket_material,
+            "blanket_rear_wall_mat": blanket_rear_wall_material,
+        },
+        cell_tallies=["TBR"],
         simulation_batches=5,
         simulation_particles_per_batch=1e4,
     )
@@ -243,7 +243,7 @@ def make_model_and_simulate():
     neutronics_model.simulate()
 
     # prints the simulation results to screen
-    print('TBR', neutronics_model.results['TBR'])
+    print("TBR", neutronics_model.results["TBR"])
 
 
 if __name__ == "__main__":

--- a/examples/shape_with_gas_production.py
+++ b/examples/shape_with_gas_production.py
@@ -16,8 +16,8 @@ def main():
         inner_radius=50,
         mid_radius=60,
         outer_radius=100,
-        material_tag='center_column_shield_mat',
-        method='pymoab'
+        material_tag="center_column_shield_mat",
+        method="pymoab",
     )
 
     # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
@@ -31,10 +31,10 @@ def main():
     my_model = paramak.NeutronicsModel(
         h5m_filename=my_shape.export_h5m(),
         source=source,
-        materials={'center_column_shield_mat': 'Be'},
-        cell_tallies=['(n,Xa)', '(n,Xt)', '(n,Xp)'],
-        mesh_tally_3d=['(n,Xa)', '(n,Xt)', '(n,Xp)'],
-        mesh_tally_2d=['(n,Xa)', '(n,Xt)', '(n,Xp)'],
+        materials={"center_column_shield_mat": "Be"},
+        cell_tallies=["(n,Xa)", "(n,Xt)", "(n,Xp)"],
+        mesh_tally_3d=["(n,Xa)", "(n,Xt)", "(n,Xp)"],
+        mesh_tally_2d=["(n,Xa)", "(n,Xt)", "(n,Xp)"],
         simulation_batches=2,
         simulation_particles_per_batch=10,
     )

--- a/examples/shape_with_spectra_cell_tally.py
+++ b/examples/shape_with_spectra_cell_tally.py
@@ -1,4 +1,3 @@
-
 import openmc
 import paramak
 import plotly.graph_objects as go
@@ -10,8 +9,8 @@ def main():
         inner_radius=50,
         mid_radius=60,
         outer_radius=100,
-        material_tag='center_column_shield_mat',
-        method='pymoab'
+        material_tag="center_column_shield_mat",
+        method="pymoab",
     )
 
     # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
@@ -25,8 +24,8 @@ def main():
     my_model = paramak.NeutronicsModel(
         h5m_filename=my_shape.export_h5m(),
         source=source,
-        materials={'center_column_shield_mat': 'Be'},
-        cell_tallies=['heating', 'flux', 'TBR', 'spectra'],
+        materials={"center_column_shield_mat": "Be"},
+        cell_tallies=["heating", "flux", "TBR", "spectra"],
         simulation_batches=2,
         simulation_particles_per_batch=20,
     )
@@ -35,74 +34,90 @@ def main():
     output_filename = my_model.simulate()
 
     # this extracts the values from the results dictionary
-    energy_bins = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['energy']
-    neutron_spectra = my_model.results['center_column_shield_mat_neutron_spectra']['Flux per source particle']['result']
-    photon_spectra = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['result']
+    energy_bins = my_model.results["center_column_shield_mat_photon_spectra"][
+        "Flux per source particle"
+    ]["energy"]
+    neutron_spectra = my_model.results["center_column_shield_mat_neutron_spectra"][
+        "Flux per source particle"
+    ]["result"]
+    photon_spectra = my_model.results["center_column_shield_mat_photon_spectra"][
+        "Flux per source particle"
+    ]["result"]
 
     fig = go.Figure()
 
     # this sets the axis titles and range
     fig.update_layout(
-        xaxis={'title': 'Energy (eV)',
-               'range': (0, 14.1e6)},
-        yaxis={'title': 'Neutrons per cm2 per source neutron'}
+        xaxis={"title": "Energy (eV)", "range": (0, 14.1e6)},
+        yaxis={"title": "Neutrons per cm2 per source neutron"},
     )
 
     # this adds the neutron spectra line to the plot
-    fig.add_trace(go.Scatter(
-        x=energy_bins[:-85],  # trims off the high energy range
-        y=neutron_spectra[:-85],  # trims off the high energy range
-        name='neutron spectra',
-        line=dict(shape='hv')
-    )
+    fig.add_trace(
+        go.Scatter(
+            x=energy_bins[:-85],  # trims off the high energy range
+            y=neutron_spectra[:-85],  # trims off the high energy range
+            name="neutron spectra",
+            line=dict(shape="hv"),
+        )
     )
 
     # this adds the photon spectra line to the plot
-    fig.add_trace(go.Scatter(
-        x=energy_bins[:-85],  # trims off the high energy range
-        y=photon_spectra[:-85],  # trims off the high energy range
-        name='photon spectra',
-        line=dict(shape='hv')
-    )
+    fig.add_trace(
+        go.Scatter(
+            x=energy_bins[:-85],  # trims off the high energy range
+            y=photon_spectra[:-85],  # trims off the high energy range
+            name="photon spectra",
+            line=dict(shape="hv"),
+        )
     )
 
     # this adds the drop down menu fo log and linear scales
     fig.update_layout(
         updatemenus=[
             go.layout.Updatemenu(
-                buttons=list([
-                    dict(
-                        args=[{
-                            "xaxis.type": 'lin', "yaxis.type": 'lin',
-                            'xaxis.range': (0, 14.1e6)
-                        }],
-                        label="linear(x) , linear(y)",
-                        method="relayout"
-                    ),
-                    dict(
-                        args=[{"xaxis.type": 'log', "yaxis.type": 'log'}],
-                        label="log(x) , log(y)",
-                        method="relayout"
-                    ),
-                    dict(
-                        args=[{"xaxis.type": 'log', "yaxis.type": 'lin'}],
-                        label="log(x) , linear(y)",
-                        method="relayout"
-                    ),
-                    dict(
-                        args=[{"xaxis.type": 'lin', "yaxis.type": 'log',
-                               'xaxis.range': (0, 14.1e6)
-                               }],
-                        label="linear(x) , log(y)",
-                        method="relayout"
-                    )
-                ]),
+                buttons=list(
+                    [
+                        dict(
+                            args=[
+                                {
+                                    "xaxis.type": "lin",
+                                    "yaxis.type": "lin",
+                                    "xaxis.range": (0, 14.1e6),
+                                }
+                            ],
+                            label="linear(x) , linear(y)",
+                            method="relayout",
+                        ),
+                        dict(
+                            args=[{"xaxis.type": "log", "yaxis.type": "log"}],
+                            label="log(x) , log(y)",
+                            method="relayout",
+                        ),
+                        dict(
+                            args=[{"xaxis.type": "log", "yaxis.type": "lin"}],
+                            label="log(x) , linear(y)",
+                            method="relayout",
+                        ),
+                        dict(
+                            args=[
+                                {
+                                    "xaxis.type": "lin",
+                                    "yaxis.type": "log",
+                                    "xaxis.range": (0, 14.1e6),
+                                }
+                            ],
+                            label="linear(x) , log(y)",
+                            method="relayout",
+                        ),
+                    ]
+                ),
                 pad={"r": 10, "t": 10},
                 showactive=True,
                 x=0.5,
                 xanchor="left",
                 y=1.1,
-                yanchor="top"
+                yanchor="top",
             ),
         ]
     )

--- a/examples/submersion_reactor_minimal.py
+++ b/examples/submersion_reactor_minimal.py
@@ -30,7 +30,7 @@ def make_model_and_simulate():
 
     # this can just be set as a string as temperature is needed for this
     # material
-    flibe = nmm.Material.from_library(name='FLiBe', temperature=773.15)
+    flibe = nmm.Material.from_library(name="FLiBe", temperature=773.15)
 
     source = openmc.Source()
     # sets the location of the source to x=0 y=0 z=0
@@ -45,14 +45,15 @@ def make_model_and_simulate():
         h5m_filename=my_reactor.export_h5m(),
         source=source,
         materials={
-            'inboard_tf_coils_mat': 'eurofer',
-            'center_column_shield_mat': 'eurofer',
-            'divertor_mat': 'eurofer',
-            'firstwall_mat': 'eurofer',
-            'blanket_rear_wall_mat': 'eurofer',
-            'blanket_mat': flibe,
-            'supports_mat': 'eurofer'},
-        cell_tallies=['flux'],
+            "inboard_tf_coils_mat": "eurofer",
+            "center_column_shield_mat": "eurofer",
+            "divertor_mat": "eurofer",
+            "firstwall_mat": "eurofer",
+            "blanket_rear_wall_mat": "eurofer",
+            "blanket_mat": flibe,
+            "supports_mat": "eurofer",
+        },
+        cell_tallies=["flux"],
         simulation_batches=5,
         simulation_particles_per_batch=1e4,
     )

--- a/install_scripts/ubuntu-20.04-install.sh
+++ b/install_scripts/ubuntu-20.04-install.sh
@@ -14,8 +14,8 @@ printf '\nexport PATH="/opt/MOAB/bin:$PATH"' >> ~/.bashrc
 printf '\nexport LD_LIBRARY_PATH="/opt/openmc/lib:$LD_LIBRARY_PATH"' >> ~/.bashrc
 printf '\nexport LD_LIBRARY_PATH="/opt/MOAB/lib:$LD_LIBRARY_PATH"' >> ~/.bashrc
 
-# CC=/usr/bin/mpicc
-# CXX=/usr/bin/mpicxx
+CC=/usr/bin/mpicc
+CXX=/usr/bin/mpicxx
 
 
 cd ~
@@ -121,9 +121,6 @@ make -j"$compile_cores" install
 
 
 # Clone and install DAGMC
-# cd /opt
-# mkdir DAGMC
-# cd DAGMC
 # TODO change to tagged release
 # git clone --single-branch --branch 3.2.0 --depth 1 https://github.com/svalinn/DAGMC.git
 git clone --single-branch --branch develop --depth 1 https://github.com/svalinn/DAGMC.git /opt/DAGMC/DAGMC
@@ -142,15 +139,14 @@ make -j"$compile_cores" install
 rm -rf /opt/DAGMC/DAGMC /opt/DAGMC/build
 
 # Clone and install OpenMC with DAGMC
-cd /opt
-git clone --recurse-submodules --branch develop https://github.com/openmc-dev/openmc.git
+git clone --recurse-submodules --branch develop https://github.com/openmc-dev/openmc.git /opt/openmc
 cd /opt/openmc
 mkdir build
 cd build
 cmake -Doptimize=on \
-        -Ddagmc=ON \
-        -DDAGMC_DIR=/opt/DAGMC/ \
-        -DHDF5_PREFER_PARALLEL=on .. 
+      -Ddagmc=ON \
+      -DDAGMC_DIR=/opt/DAGMC/ \
+      -DHDF5_PREFER_PARALLEL=on .. 
 make -j"$compile_cores"
 sudo make -j"$compile_cores" install
 cd /opt/openmc

--- a/paramak_neutronics/neutronics_model.py
+++ b/paramak_neutronics/neutronics_model.py
@@ -477,9 +477,6 @@ class NeutronicsModel:
         silently_remove_file("settings.xml")
         silently_remove_file("tallies.xml")
 
-        # materials.xml is removed in this function
-        self.create_openmc_materials()
-
         # this is the underlying geometry container that is filled with the
         # faceteted DAGMC CAD model
         dag_univ = openmc.DAGMCUniverse(self.h5m_filename)
@@ -645,6 +642,9 @@ class NeutronicsModel:
                     score = standard_tally
                     sufix = standard_tally
                     self._add_tally_for_every_material(sufix, score)
+
+        # materials.xml is removed in this function
+        self.create_openmc_materials()
 
         # make the model from geometry, materials, settings and tallies
         model = openmc.model.Model(geom, self.mats, settings, self.tallies)

--- a/paramak_neutronics/neutronics_model.py
+++ b/paramak_neutronics/neutronics_model.py
@@ -503,6 +503,10 @@ class NeutronicsModel:
             mesh_xyz = openmc.RegularMesh(mesh_id=1, name="3d_mesh")
             mesh_xyz.dimension = self.mesh_3d_resolution
             if self.mesh_3d_corners is None:
+
+                if self.bounding_box is None:
+                    self.bounding_box = self.find_bounding_box()
+
                 mesh_xyz.lower_left = self.bounding_box[0]
                 mesh_xyz.upper_right = self.bounding_box[1]
             else:
@@ -529,7 +533,25 @@ class NeutronicsModel:
                 self.mesh_2d_resolution[0],
             ]
 
+            mesh_xy = openmc.RegularMesh(mesh_id=3, name="2d_mesh_xy")
+            mesh_xy.dimension = [
+                self.mesh_2d_resolution[1],
+                self.mesh_2d_resolution[0],
+                1,
+            ]
+
+            mesh_yz = openmc.RegularMesh(mesh_id=4, name="2d_mesh_yz")
+            mesh_yz.dimension = [
+                1,
+                self.mesh_2d_resolution[1],
+                self.mesh_2d_resolution[0],
+            ]
+
             if self.mesh_2d_corners is None:
+
+                if self.bounding_box is None:
+                    self.bounding_box = self.find_bounding_box()
+
                 mesh_xz.lower_left = [
                     self.bounding_box[0][0],
                     -1,
@@ -541,18 +563,7 @@ class NeutronicsModel:
                     1,
                     self.bounding_box[1][2],
                 ]
-            else:
-                mesh_xz.lower_left = self.mesh_2d_corners[0]
-                mesh_xz.upper_right = self.mesh_2d_corners[1]
 
-            mesh_xy = openmc.RegularMesh(mesh_id=3, name="2d_mesh_xy")
-            mesh_xy.dimension = [
-                self.mesh_2d_resolution[1],
-                self.mesh_2d_resolution[0],
-                1,
-            ]
-
-            if self.mesh_2d_corners is None:
                 mesh_xy.lower_left = [
                     self.bounding_box[0][0],
                     self.bounding_box[0][1],
@@ -564,18 +575,7 @@ class NeutronicsModel:
                     self.bounding_box[1][1],
                     1,
                 ]
-            else:
-                mesh_xy.lower_left = self.mesh_2d_corners[0]
-                mesh_xy.upper_right = self.mesh_2d_corners[1]
 
-            mesh_yz = openmc.RegularMesh(mesh_id=4, name="2d_mesh_yz")
-            mesh_yz.dimension = [
-                1,
-                self.mesh_2d_resolution[1],
-                self.mesh_2d_resolution[0],
-            ]
-
-            if self.mesh_2d_corners is None:
                 mesh_yz.lower_left = [
                     -1,
                     self.bounding_box[0][1],
@@ -587,9 +587,17 @@ class NeutronicsModel:
                     self.bounding_box[1][1],
                     self.bounding_box[1][2],
                 ]
+
             else:
+                mesh_xz.lower_left = self.mesh_2d_corners[0]
+                mesh_xz.upper_right = self.mesh_2d_corners[1]
+
+                mesh_xy.lower_left = self.mesh_2d_corners[0]
+                mesh_xy.upper_right = self.mesh_2d_corners[1]
+
                 mesh_yz.lower_left = self.mesh_2d_corners[0]
                 mesh_yz.upper_right = self.mesh_2d_corners[1]
+
 
             for standard_tally in self.mesh_tally_2d:
                 score = standard_tally

--- a/paramak_neutronics/neutronics_model.py
+++ b/paramak_neutronics/neutronics_model.py
@@ -609,6 +609,9 @@ class NeutronicsModel:
                     tally.scores = [score]
                     self.tallies.append(tally)
 
+        # materials.xml is removed in this function
+        self.create_openmc_materials()
+
         if self.cell_tallies is not None:
 
             for standard_tally in self.cell_tallies:
@@ -642,9 +645,6 @@ class NeutronicsModel:
                     score = standard_tally
                     sufix = standard_tally
                     self._add_tally_for_every_material(sufix, score)
-
-        # materials.xml is removed in this function
-        self.create_openmc_materials()
 
         # make the model from geometry, materials, settings and tallies
         model = openmc.model.Model(geom, self.mats, settings, self.tallies)

--- a/paramak_neutronics/neutronics_model.py
+++ b/paramak_neutronics/neutronics_model.py
@@ -19,8 +19,10 @@ from .neutronics_utils import (
 try:
     import neutronics_material_maker as nmm
 except ImportError:
-    msg = ("neutronics_material_maker not found, NeutronicsModel.materials "
-           "can't accept strings or neutronics_material_maker objects")
+    msg = (
+        "neutronics_material_maker not found, NeutronicsModel.materials "
+        "can't accept strings or neutronics_material_maker objects"
+    )
     warnings.warn(msg, UserWarning)
 
 
@@ -99,7 +101,9 @@ class NeutronicsModel:
         photon_transport: Optional[bool] = True,
         # convert from watts to activity source_activity
         max_lost_particles: Optional[int] = 10,
-        bounding_box: Tuple[Tuple[float,float,float], Tuple[float, float,float]] = None,
+        bounding_box: Tuple[
+            Tuple[float, float, float], Tuple[float, float, float]
+        ] = None,
     ):
         self.materials = materials
         self.h5m_filename = h5m_filename
@@ -123,7 +127,7 @@ class NeutronicsModel:
         self.tallies = None
         self.output_filename = None
         self.statepoint_filename = None
-    
+
         # find_bounding_box can be used to populate this
         self.bounding_box = bounding_box
 
@@ -331,7 +335,7 @@ class NeutronicsModel:
         """Computes the bounding box of the DAGMC geometry"""
 
         if not Path(self.h5m_filename).is_file:
-            msg = f'h5m file with filename {self.h5m_filename} not found'
+            msg = f"h5m file with filename {self.h5m_filename} not found"
             raise FileNotFoundError(msg)
         dag_univ = openmc.DAGMCUniverse(self.h5m_filename, auto_geom_ids=False)
 
@@ -366,7 +370,10 @@ class NeutronicsModel:
         silently_remove_file("geometry.xml")
         silently_remove_file("materials.xml")
 
-        return ((bbox[0][0], bbox[0][1], bbox[0][2]), (bbox[1][0], bbox[1][1], bbox[1][2]))
+        return (
+            (bbox[0][0], bbox[0][1], bbox[0][2]),
+            (bbox[1][0], bbox[1][1], bbox[1][2]),
+        )
 
     # def build_csg_graveyard(self):
 

--- a/tests/notebook_testing.py
+++ b/tests/notebook_testing.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 
@@ -12,22 +11,17 @@ def notebook_run(path):
     Execute a notebook via nbconvert and collect output.
     :returns (parsed nb object, execution errors)
     """
-    kernel_name = 'python%d' % sys.version_info[0]
+    kernel_name = "python%d" % sys.version_info[0]
     this_file_directory = os.path.dirname(__file__)
     errors = []
 
     with open(path) as file:
         note_book = nbformat.read(file, as_version=4)
-        note_book.metadata.get('kernelspec', {})['name'] = kernel_name
-        ep = ExecutePreprocessor(
-            kernel_name=kernel_name,
-            timeout=800)
+        note_book.metadata.get("kernelspec", {})["name"] = kernel_name
+        ep = ExecutePreprocessor(kernel_name=kernel_name, timeout=800)
 
         try:
-            ep.preprocess(
-                note_book, {
-                    'metadata': {
-                        'path': this_file_directory}})
+            ep.preprocess(note_book, {"metadata": {"path": this_file_directory}})
 
         except CellExecutionError as e:
             if "SKIP" in e.traceback:

--- a/tests/test_example_neutronics_simulations.py
+++ b/tests/test_example_neutronics_simulations.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 import unittest
@@ -6,11 +5,10 @@ from pathlib import Path
 
 from .notebook_testing import notebook_run
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'examples'))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "examples"))
 
 
 class TestExampleNeutronics(unittest.TestCase):
-
     def test_jupyter_notebooks_example_neutronics_simulations(self):
         for notebook in Path().rglob("examples/example_neutronics_simulations/*.ipynb"):
             print(notebook)

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -1,4 +1,3 @@
-
 import os
 import unittest
 from pathlib import Path
@@ -19,8 +18,8 @@ class TestShape(unittest.TestCase):
             inner_radius=50,
             mid_radius=60,
             outer_radius=100,
-            material_tag='center_column_shield_mat',
-            method='pymoab'
+            material_tag="center_column_shield_mat",
+            method="pymoab",
         )
 
         self.h5m_filename = self.my_shape.export_h5m()
@@ -36,12 +35,12 @@ class TestShape(unittest.TestCase):
     def simulation_with_previous_h5m_file(self):
         """This performs a simulation using previously created h5m file"""
 
-        os.system('rm *.h5m')
+        os.system("rm *.h5m")
 
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': 'WC'},
+            materials={"center_column_shield_mat": "WC"},
         )
 
         my_model.simulate()
@@ -52,15 +51,15 @@ class TestShape(unittest.TestCase):
         """Makes a neutronics model and simulates with a cell tally"""
 
         test_mat = openmc.Material()
-        test_mat.add_element('Fe', 1.0)
-        test_mat.set_density(units='g/cm3', density=4.2)
+        test_mat.add_element("Fe", 1.0)
+        test_mat.set_density(units="g/cm3", density=4.2)
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': test_mat},
-            cell_tallies=['heating'],
+            materials={"center_column_shield_mat": test_mat},
+            cell_tallies=["heating"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
@@ -68,26 +67,26 @@ class TestShape(unittest.TestCase):
         # performs an openmc simulation on the model
         output_filename = my_model.simulate()
 
-        assert output_filename.name == 'statepoint.2.h5'
+        assert output_filename.name == "statepoint.2.h5"
 
         results = openmc.StatePoint(output_filename)
         assert len(results.tallies.items()) == 1
 
         # extracts the heat from the results dictionary
-        heat = my_model.results['center_column_shield_mat_heating']['Watts']['result']
+        heat = my_model.results["center_column_shield_mat_heating"]["Watts"]["result"]
         assert heat > 0
 
     def test_neutronics_component_simulation_with_nmm(self):
         """Makes a neutronics model and simulates with a cell tally"""
 
-        test_mat = nmm.Material.from_library('Be')
+        test_mat = nmm.Material.from_library("Be")
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': test_mat},
-            cell_tallies=['heating'],
+            materials={"center_column_shield_mat": test_mat},
+            cell_tallies=["heating"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
@@ -99,264 +98,214 @@ class TestShape(unittest.TestCase):
         assert len(results.tallies.items()) == 1
 
         # extracts the heat from the results dictionary
-        heat = my_model.results['center_column_shield_mat_heating']['Watts']['result']
+        heat = my_model.results["center_column_shield_mat_heating"]["Watts"]["result"]
         assert heat > 0
 
     def test_cell_tally_output_file_creation(self):
         """Performs a neutronics simulation and checks the cell tally output
         file is created and named correctly"""
 
-        os.system('rm custom_name.json')
-        os.system('rm results.json')
+        os.system("rm custom_name.json")
+        os.system("rm results.json")
 
         test_mat = openmc.Material()
-        test_mat.add_element('Fe', 1.0)
-        test_mat.set_density(units='g/cm3', density=4.2)
+        test_mat.add_element("Fe", 1.0)
+        test_mat.set_density(units="g/cm3", density=4.2)
 
         # converts the geometry into a neutronics geometry
         # this simulation has no tally to test this edge case
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': test_mat},
+            materials={"center_column_shield_mat": test_mat},
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
 
         # performs an openmc simulation on the model
         output_filename = my_model.simulate(
-            cell_tally_results_filename='custom_name.json'
+            cell_tally_results_filename="custom_name.json"
         )
 
-        assert output_filename.name == 'statepoint.2.h5'
-        assert Path('custom_name.json').exists() is True
+        assert output_filename.name == "statepoint.2.h5"
+        assert Path("custom_name.json").exists() is True
 
-        assert Path('results.json').exists() is False
+        assert Path("results.json").exists() is False
         output_filename = my_model.simulate()
-        assert Path('results.json').exists() is True
+        assert Path("results.json").exists() is True
 
     def test_incorrect_faceting_tolerance(self):
-
         def incorrect_faceting_tolerance():
             """Sets faceting_tolerance as a string which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                faceting_tolerance='coucou'
+                materials={"center_column_shield_mat": "eurofer"},
+                faceting_tolerance="coucou",
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_faceting_tolerance
-        )
+        self.assertRaises(TypeError, incorrect_faceting_tolerance)
 
     def test_incorrect_merge_tolerance(self):
-
         def incorrect_merge_tolerance():
             """Set merge_tolerance as a string which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                merge_tolerance='coucou'
+                materials={"center_column_shield_mat": "eurofer"},
+                merge_tolerance="coucou",
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_merge_tolerance
-        )
+        self.assertRaises(TypeError, incorrect_merge_tolerance)
 
     def test_incorrect_cell_tallies(self):
-
         def incorrect_cell_tallies():
             """Set a cell tally that is not accepted which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                cell_tallies=['coucou'],
+                materials={"center_column_shield_mat": "eurofer"},
+                cell_tallies=["coucou"],
             )
 
-        self.assertRaises(
-            ValueError,
-            incorrect_cell_tallies
-        )
+        self.assertRaises(ValueError, incorrect_cell_tallies)
 
     def test_incorrect_cell_tally_type(self):
-
         def incorrect_cell_tally_type():
             """Set a cell tally that is the wrong type which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
+                materials={"center_column_shield_mat": "eurofer"},
                 cell_tallies=1,
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_cell_tally_type
-        )
+        self.assertRaises(TypeError, incorrect_cell_tally_type)
 
     def test_incorrect_mesh_tally_2d(self):
-
         def incorrect_mesh_tally_2d():
             """Set a mesh_tally_2d that is not accepted which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                mesh_tally_2d=['coucou'],
+                materials={"center_column_shield_mat": "eurofer"},
+                mesh_tally_2d=["coucou"],
             )
 
-        self.assertRaises(
-            ValueError,
-            incorrect_mesh_tally_2d
-        )
+        self.assertRaises(ValueError, incorrect_mesh_tally_2d)
 
     def test_incorrect_mesh_tally_2d_type(self):
-
         def incorrect_mesh_tally_2d_type():
             """Set a mesh_tally_2d that is the wrong type which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
+                materials={"center_column_shield_mat": "eurofer"},
                 mesh_tally_2d=1,
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_mesh_tally_2d_type
-        )
+        self.assertRaises(TypeError, incorrect_mesh_tally_2d_type)
 
     def test_incorrect_mesh_tally_3d(self):
-
         def incorrect_mesh_tally_3d():
             """Set a mesh_tally_3d that is not accepted which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                mesh_tally_3d=['coucou'],
+                materials={"center_column_shield_mat": "eurofer"},
+                mesh_tally_3d=["coucou"],
             )
 
-        self.assertRaises(
-            ValueError,
-            incorrect_mesh_tally_3d
-        )
+        self.assertRaises(ValueError, incorrect_mesh_tally_3d)
 
     def test_incorrect_mesh_tally_3d_type(self):
-
         def incorrect_mesh_tally_3d_type():
             """Set a mesh_tally_3d that is the wrong type which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
+                materials={"center_column_shield_mat": "eurofer"},
                 mesh_tally_3d=1,
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_mesh_tally_3d_type
-        )
+        self.assertRaises(TypeError, incorrect_mesh_tally_3d_type)
 
     def test_incorrect_materials(self):
-
         def incorrect_materials():
             """Set a material as a string which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials='coucou',
+                materials="coucou",
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_materials
-        )
+        self.assertRaises(TypeError, incorrect_materials)
 
     def test_incorrect_materials_type(self):
-
         def incorrect_materials_type():
             """Sets a material as an int which should raise an error"""
             test_model = paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 23},
+                materials={"center_column_shield_mat": 23},
             )
 
             test_model.create_openmc_materials()
 
-        self.assertRaises(
-            TypeError,
-            incorrect_materials_type
-        )
+        self.assertRaises(TypeError, incorrect_materials_type)
 
     def test_incorrect_simulation_batches_to_small(self):
-
         def incorrect_simulation_batches_to_small():
             """Sets simulation batch below 2 which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                simulation_batches=1
+                materials={"center_column_shield_mat": "eurofer"},
+                simulation_batches=1,
             )
 
-        self.assertRaises(
-            ValueError,
-            incorrect_simulation_batches_to_small
-        )
+        self.assertRaises(ValueError, incorrect_simulation_batches_to_small)
 
     def test_incorrect_simulation_batches_wrong_type(self):
-
         def incorrect_simulation_batches_wrong_type():
             """Sets simulation_batches as a string which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                simulation_batches='one'
+                materials={"center_column_shield_mat": "eurofer"},
+                simulation_batches="one",
             )
 
-        self.assertRaises(
-            TypeError,
-            incorrect_simulation_batches_wrong_type
-        )
+        self.assertRaises(TypeError, incorrect_simulation_batches_wrong_type)
 
     def test_incorrect_simulation_particles_per_batch_wrong_type(self):
-
         def incorrect_simulation_particles_per_batch_wrong_type():
             """Sets simulation_particles_per_batch below 2 which should raise an error"""
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'eurofer'},
-                simulation_particles_per_batch='one'
+                materials={"center_column_shield_mat": "eurofer"},
+                simulation_particles_per_batch="one",
             )
 
         self.assertRaises(
-            TypeError,
-            incorrect_simulation_particles_per_batch_wrong_type
+            TypeError, incorrect_simulation_particles_per_batch_wrong_type
         )
 
     def test_neutronics_component_cell_simulation_heating(self):
         """Makes a neutronics model and simulates with a cell tally"""
 
-        os.system('rm *.h5')
+        os.system("rm *.h5")
         mat = openmc.Material()
-        mat.add_element('Li', 1)
-        mat.set_density('g/cm3', 2.1)
+        mat.add_element("Li", 1)
+        mat.set_density("g/cm3", 2.1)
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': mat},
-            cell_tallies=['heating', 'flux', 'TBR', 'spectra'],
+            materials={"center_column_shield_mat": mat},
+            cell_tallies=["heating", "flux", "TBR", "spectra"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
@@ -371,13 +320,21 @@ class TestShape(unittest.TestCase):
         assert len(results.meshes) == 0
 
         # extracts the heat from the results dictionary
-        heat = my_model.results['center_column_shield_mat_heating']['Watts']['result']
-        flux = my_model.results['center_column_shield_mat_flux']['Flux per source particle']['result']
-        mat_tbr = my_model.results['center_column_shield_mat_TBR']['result']
-        tbr = my_model.results['TBR']['result']
-        spectra_neutrons = my_model.results['center_column_shield_mat_neutron_spectra']['Flux per source particle']['result']
-        spectra_photons = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['result']
-        energy = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['energy']
+        heat = my_model.results["center_column_shield_mat_heating"]["Watts"]["result"]
+        flux = my_model.results["center_column_shield_mat_flux"][
+            "Flux per source particle"
+        ]["result"]
+        mat_tbr = my_model.results["center_column_shield_mat_TBR"]["result"]
+        tbr = my_model.results["TBR"]["result"]
+        spectra_neutrons = my_model.results["center_column_shield_mat_neutron_spectra"][
+            "Flux per source particle"
+        ]["result"]
+        spectra_photons = my_model.results["center_column_shield_mat_photon_spectra"][
+            "Flux per source particle"
+        ]["result"]
+        energy = my_model.results["center_column_shield_mat_photon_spectra"][
+            "Flux per source particle"
+        ]["energy"]
 
         assert heat > 0
         assert flux > 0
@@ -391,15 +348,15 @@ class TestShape(unittest.TestCase):
     def test_neutronics_component_2d_mesh_simulation(self):
         """Makes a neutronics model and simulates with a 2D mesh tally"""
 
-        os.system('rm *_on_2D_mesh_*.png')
-        os.system('rm *.h5')
+        os.system("rm *_on_2D_mesh_*.png")
+        os.system("rm *.h5")
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': 'Be'},
-            mesh_tally_2d=['heating'],
+            materials={"center_column_shield_mat": "Be"},
+            mesh_tally_2d=["heating"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
@@ -419,14 +376,14 @@ class TestShape(unittest.TestCase):
         """Makes a neutronics model and simulates with a 3D mesh tally and
         checks that the vtk file is produced"""
 
-        os.system('rm *.h5')
+        os.system("rm *.h5")
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': 'Be'},
-            mesh_tally_3d=['heating', '(n,Xt)'],
+            materials={"center_column_shield_mat": "Be"},
+            mesh_tally_3d=["heating", "(n,Xt)"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
@@ -439,23 +396,23 @@ class TestShape(unittest.TestCase):
         assert len(results.tallies.items()) == 2
 
         assert Path(output_filename).exists() is True
-        assert Path('heating_on_3D_mesh.vtk').exists() is True
-        assert Path('n-Xt_on_3D_mesh.vtk').exists() is True
+        assert Path("heating_on_3D_mesh.vtk").exists() is True
+        assert Path("n-Xt_on_3D_mesh.vtk").exists() is True
 
     def test_batches_and_particles_convert_to_int(self):
         """Makes a neutronics model and simulates with a 3D and 2D mesh tally
         and checks that the vtk and png files are produced. This checks the
         mesh ID values don't overlap"""
 
-        os.system('rm *.h5')
+        os.system("rm *.h5")
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': 'Be'},
+            materials={"center_column_shield_mat": "Be"},
             simulation_batches=3.1,
-            simulation_particles_per_batch=2.1
+            simulation_particles_per_batch=2.1,
         )
 
         assert isinstance(my_model.simulation_batches, int)
@@ -468,15 +425,15 @@ class TestShape(unittest.TestCase):
         and checks that the vtk and png files are produced. This checks the
         mesh ID values don't overlap"""
 
-        os.system('rm *.h5')
+        os.system("rm *.h5")
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': 'Be'},
-            mesh_tally_3d=['heating'],
-            mesh_tally_2d=['heating'],
+            materials={"center_column_shield_mat": "Be"},
+            mesh_tally_3d=["heating"],
+            mesh_tally_2d=["heating"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
         )
@@ -488,26 +445,25 @@ class TestShape(unittest.TestCase):
         assert len(results.tallies.items()) == 4  # one 3D and three 2D
 
         assert Path(output_filename).exists() is True
-        assert Path('heating_on_3D_mesh.vtk').exists() is True
+        assert Path("heating_on_3D_mesh.vtk").exists() is True
         assert Path("heating_on_2D_mesh_xz.png").exists() is True
         assert Path("heating_on_2D_mesh_xy.png").exists() is True
         assert Path("heating_on_2D_mesh_yz.png").exists() is True
 
-    def test_neutronics_component_3d_and_2d_mesh_simulation_with_corner_points(
-            self):
+    def test_neutronics_component_3d_and_2d_mesh_simulation_with_corner_points(self):
         """Makes a neutronics model and simulates with a 3D and 2D mesh tally
         and checks that the vtk and png files are produced. This checks the
         mesh ID values don't overlap"""
 
-        os.system('rm *.h5')
+        os.system("rm *.h5")
 
         # converts the geometry into a neutronics geometry
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=self.h5m_filename,
             source=self.source,
-            materials={'center_column_shield_mat': 'Be'},
-            mesh_tally_3d=['heating'],
-            mesh_tally_2d=['heating'],
+            materials={"center_column_shield_mat": "Be"},
+            mesh_tally_3d=["heating"],
+            mesh_tally_2d=["heating"],
             simulation_batches=2,
             simulation_particles_per_batch=2,
             mesh_3d_corners=[(0, 0, 0), (10, 10, 10)],
@@ -523,7 +479,7 @@ class TestShape(unittest.TestCase):
         assert len(results.tallies.items()) == 4  # one 3D and three 2D
 
         assert Path(output_filename).exists() is True
-        assert Path('heating_on_3D_mesh.vtk').exists() is True
+        assert Path("heating_on_3D_mesh.vtk").exists() is True
         assert Path("heating_on_2D_mesh_xz.png").exists() is True
         assert Path("heating_on_2D_mesh_xy.png").exists() is True
         assert Path("heating_on_2D_mesh_yz.png").exists() is True
@@ -534,12 +490,12 @@ class TestShape(unittest.TestCase):
 
         test_shape = paramak.RotateStraightShape(
             points=[(0, 10), (0, 20), (20, 20)],
-            material_tag='mat1',
+            material_tag="mat1",
         )
         test_shape2 = paramak.RotateSplineShape(
             points=[(100, 100), (100, -100), (200, -100), (200, 100)],
-            material_tag='blanket_mat',
-            rotation_angle=180
+            material_tag="blanket_mat",
+            rotation_angle=180,
         )
 
         test_reactor = paramak.Reactor([test_shape, test_shape2])
@@ -548,10 +504,10 @@ class TestShape(unittest.TestCase):
             h5m_filename=test_reactor.export_h5m(),
             source=self.source,
             materials={
-                'mat1': 'copper',
-                'blanket_mat': 'FLiNaK',  # used as O18 is not in nndc nuc data
+                "mat1": "copper",
+                "blanket_mat": "FLiNaK",  # used as O18 is not in nndc nuc data
             },
-            cell_tallies=['TBR', 'heating', 'flux'],
+            cell_tallies=["TBR", "heating", "flux"],
             simulation_batches=2,
             simulation_particles_per_batch=10,
         )
@@ -563,16 +519,16 @@ class TestShape(unittest.TestCase):
         """Makes a reactor from two shapes, then mades a neutronics model
         and tests the TBR simulation value"""
 
-        os.system('rm *_on_2D_mesh_*.png')
+        os.system("rm *_on_2D_mesh_*.png")
 
         test_shape = paramak.RotateStraightShape(
             points=[(0, 10), (0, 20), (20, 20)],
-            material_tag='mat1',
+            material_tag="mat1",
         )
         test_shape2 = paramak.RotateSplineShape(
             points=[(100, 100), (100, -100), (200, -100), (200, 100)],
-            material_tag='blanket_mat',
-            rotation_angle=180
+            material_tag="blanket_mat",
+            rotation_angle=180,
         )
 
         test_reactor = paramak.Reactor([test_shape, test_shape2])
@@ -581,10 +537,10 @@ class TestShape(unittest.TestCase):
             h5m_filename=test_reactor.export_h5m(),
             source=self.source,
             materials={
-                'mat1': 'copper',
-                'blanket_mat': 'FLiNaK',  # used as O18 is not in nndc nuc data
+                "mat1": "copper",
+                "blanket_mat": "FLiNaK",  # used as O18 is not in nndc nuc data
             },
-            mesh_tally_2d=['(n,Xt)', 'heating', 'flux'],
+            mesh_tally_2d=["(n,Xt)", "heating", "flux"],
             simulation_batches=2,
             simulation_particles_per_batch=10,
         )
@@ -610,11 +566,11 @@ class TestShape(unittest.TestCase):
         def test_export_h5m_error_handling():
             """Makes a reactor from two shapes, then mades a neutronics model
             and tests the TBR simulation value"""
-            self.my_shape.method = 'cubit'
+            self.my_shape.method = "cubit"
             paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'WC'},
+                materials={"center_column_shield_mat": "WC"},
             )
 
             self.my_shape.export_h5m()
@@ -632,18 +588,16 @@ class TestShape(unittest.TestCase):
             my_model = paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'WC'},
+                materials={"center_column_shield_mat": "WC"},
             )
 
             # creates h5m files so that the code passes the h5m file check
-            os.system('touch dagmc.h5m')
-            os.system('rm *.xml')
+            os.system("touch dagmc.h5m")
+            os.system("rm *.xml")
 
             my_model.simulate(export_xml=False)
 
-        self.assertRaises(
-            FileNotFoundError,
-            test_missing_xml_file_error_handling)
+        self.assertRaises(FileNotFoundError, test_missing_xml_file_error_handling)
 
     def test_simulations_with_missing_h5m_files(self):
         """Creates NeutronicsModel objects and trys to perform simulation
@@ -656,21 +610,19 @@ class TestShape(unittest.TestCase):
             my_model = paramak_neutronics.NeutronicsModel(
                 h5m_filename=self.h5m_filename,
                 source=self.source,
-                materials={'center_column_shield_mat': 'WC'},
+                materials={"center_column_shield_mat": "WC"},
             )
 
             # creates xml files so that the code passes the xml file check
-            os.system('touch geometry.xml')
-            os.system('touch materials.xml')
-            os.system('touch settings.xml')
-            os.system('touch tallies.xml')
-            os.system('rm dagmc.h5m')
+            os.system("touch geometry.xml")
+            os.system("touch materials.xml")
+            os.system("touch settings.xml")
+            os.system("touch tallies.xml")
+            os.system("rm dagmc.h5m")
 
             my_model.simulate(export_h5m=False)
 
-        self.assertRaises(
-            FileNotFoundError,
-            test_missing_h5m_file_error_handling)
+        self.assertRaises(FileNotFoundError, test_missing_h5m_file_error_handling)
 
 
 class TestNeutronicsBallReactor(unittest.TestCase):
@@ -700,9 +652,10 @@ class TestNeutronicsBallReactor(unittest.TestCase):
         self.blanket_material = nmm.Material.from_mixture(
             fracs=[0.8, 0.2],
             materials=[
-                nmm.Material.from_library('SiC'),
-                nmm.Material.from_library('eurofer')
-            ])
+                nmm.Material.from_library("SiC"),
+                nmm.Material.from_library("eurofer"),
+            ],
+        )
 
         self.source = openmc.Source()
         # sets the location of the source to x=0 y=0 z=0
@@ -718,30 +671,32 @@ class TestNeutronicsBallReactor(unittest.TestCase):
         # makes the neutronics material
         neutronics_model = paramak_neutronics.NeutronicsModel(
             source=openmc.Source(),
-            h5m_filename='placeholder.h5m',
+            h5m_filename="placeholder.h5m",
             materials={
-                'inboard_tf_coils_mat': 'copper',
-                'center_column_shield_mat': 'WC',
-                'divertor_mat': 'eurofer',
-                'firstwall_mat': 'eurofer',
-                'blanket_mat': self.blanket_material,  # use of homogenised material
-                'blanket_rear_wall_mat': 'eurofer'},
-            cell_tallies=['TBR', 'flux', 'heating'],
+                "inboard_tf_coils_mat": "copper",
+                "center_column_shield_mat": "WC",
+                "divertor_mat": "eurofer",
+                "firstwall_mat": "eurofer",
+                "blanket_mat": self.blanket_material,  # use of homogenised material
+                "blanket_rear_wall_mat": "eurofer",
+            },
+            cell_tallies=["TBR", "flux", "heating"],
             simulation_batches=42,
             simulation_particles_per_batch=12,
         )
 
-        assert neutronics_model.h5m_filename == 'placeholder.h5m'
+        assert neutronics_model.h5m_filename == "placeholder.h5m"
 
         assert neutronics_model.materials == {
-            'inboard_tf_coils_mat': 'copper',
-            'center_column_shield_mat': 'WC',
-            'divertor_mat': 'eurofer',
-            'firstwall_mat': 'eurofer',
-            'blanket_mat': self.blanket_material,
-            'blanket_rear_wall_mat': 'eurofer'}
+            "inboard_tf_coils_mat": "copper",
+            "center_column_shield_mat": "WC",
+            "divertor_mat": "eurofer",
+            "firstwall_mat": "eurofer",
+            "blanket_mat": self.blanket_material,
+            "blanket_rear_wall_mat": "eurofer",
+        }
 
-        assert neutronics_model.cell_tallies == ['TBR', 'flux', 'heating']
+        assert neutronics_model.cell_tallies == ["TBR", "flux", "heating"]
 
         assert neutronics_model.simulation_batches == 42
         assert isinstance(neutronics_model.simulation_batches, int)

--- a/tests/test_neutronics_model.py
+++ b/tests/test_neutronics_model.py
@@ -620,7 +620,7 @@ class TestShape(unittest.TestCase):
             os.system("touch tallies.xml")
             os.system("rm dagmc.h5m")
 
-            my_model.simulate(export_h5m=False)
+            my_model.simulate()
 
         self.assertRaises(FileNotFoundError, test_missing_h5m_file_error_handling)
 

--- a/tests/test_neutronics_utils.py
+++ b/tests/test_neutronics_utils.py
@@ -1,4 +1,3 @@
-
 import json
 import os
 import unittest
@@ -12,7 +11,6 @@ from paramak.utils import add_stl_to_moab_core, define_moab_core_and_tags
 
 
 class TestNeutronicsUtilityFunctions(unittest.TestCase):
-
     def test_create_inital_source_file(self):
         """Creates an initial_source.h5 from a point source"""
 
@@ -38,15 +36,16 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
 
         paramak_neutronics.create_inital_particles(source, 10)
 
-        for view_plane in ['XZ', 'XY', 'YZ', 'YX', 'ZY', 'ZX', 'RZ', 'XYZ']:
+        for view_plane in ["XZ", "XY", "YZ", "YX", "ZY", "ZX", "RZ", "XYZ"]:
 
             points = paramak_neutronics.extract_points_from_initial_source(
-                view_plane=view_plane)
+                view_plane=view_plane
+            )
 
             assert len(points) == 10
 
             for point in points:
-                if view_plane == 'XYZ':
+                if view_plane == "XYZ":
                     assert len(point) == 3
                     assert point[0] == 0
                     assert point[1] == 0
@@ -68,9 +67,7 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
 
             paramak_neutronics.create_inital_particles(source, 10)
 
-            paramak_neutronics.extract_points_from_initial_source(
-                view_plane='coucou'
-            )
+            paramak_neutronics.extract_points_from_initial_source(view_plane="coucou")
 
         self.assertRaises(ValueError, incorrect_viewplane)
 
@@ -78,18 +75,18 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
         """exports a h5m with specific material tags and checks they are
         found using the find_material_groups_in_h5m utility function"""
 
-        os.system('rm *.stl *.h5m')
+        os.system("rm *.stl *.h5m")
 
         pf_coil = paramak.PoloidalFieldCoil(
             height=10,
             width=10,
             center_point=(100, 0),
             rotation_angle=180,
-            material_tag='copper'
+            material_tag="copper",
         )
 
         pf_coil.export_h5m_with_pymoab(
-            filename='dagmc.h5',  # missing the m, but this is added
+            filename="dagmc.h5",  # missing the m, but this is added
             include_graveyard=True,
         )
 
@@ -98,31 +95,29 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
         )
 
         assert len(list_of_mats) == 2
-        assert 'mat:copper' in list_of_mats
-        assert 'mat:graveyard' in list_of_mats
+        assert "mat:copper" in list_of_mats
+        assert "mat:graveyard" in list_of_mats
 
     def test_find_volume_ids_in_h5_file(self):
         """exports a h5m with a known number of volumes and checks they are
         found using the find_volume_ids_in_h5m utility function"""
 
-        os.system('rm *.stl *.h5m')
+        os.system("rm *.stl *.h5m")
 
         pf_coil = paramak.PoloidalFieldCoil(
             height=10,
             width=10,
             center_point=(100, 0),
             rotation_angle=180,
-            material_tag='copper'
+            material_tag="copper",
         )
 
         pf_coil.export_h5m_with_pymoab(
-            filename='dagmc.h5',  # missing the m, but this is added
+            filename="dagmc.h5",  # missing the m, but this is added
             include_graveyard=True,
         )
 
-        list_of_mats = paramak_neutronics.find_volume_ids_in_h5m(
-            filename="dagmc.h5m"
-        )
+        list_of_mats = paramak_neutronics.find_volume_ids_in_h5m(filename="dagmc.h5m")
 
         assert len(list_of_mats) == 2
         assert 1 in list_of_mats
@@ -131,7 +126,7 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
         """Creates an initial source file using create_inital_particles utility
         and checks the file exists and that the points are correct"""
 
-        os.system('rm *.h5')
+        os.system("rm *.h5")
 
         source = openmc.Source()
         source.space = openmc.stats.Point((1, 2, 3))
@@ -139,15 +134,14 @@ class TestNeutronicsUtilityFunctions(unittest.TestCase):
         source.angle = openmc.stats.Isotropic()
 
         source_file = paramak_neutronics.create_inital_particles(
-            source=source,
-            number_of_source_particles=10
+            source=source, number_of_source_particles=10
         )
 
         assert source_file == "initial_source.h5"
         assert Path(source_file).exists() is True
 
         points = paramak_neutronics.extract_points_from_initial_source(
-            view_plane='XYZ', input_filename=source_file
+            view_plane="XYZ", input_filename=source_file
         )
 
         assert len(points) == 10

--- a/tests/test_reactor_neutronics.py
+++ b/tests/test_reactor_neutronics.py
@@ -33,8 +33,7 @@ class TestNeutronicsModelWithReactor(unittest.TestCase):
     def test_bounding_box_size(self):
 
         h5m_filename = self.test_reactor.export_h5m_with_pymoab(
-            include_graveyard=False,
-            faceting_tolerance=1e-1
+            include_graveyard=False, faceting_tolerance=1e-1
         )
 
         # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
@@ -43,25 +42,25 @@ class TestNeutronicsModelWithReactor(unittest.TestCase):
         source.space = openmc.stats.Point((0, 0, 0))
         source.angle = openmc.stats.Isotropic()
         source.energy = openmc.stats.Discrete([14e6], [1])
-                
-        h5m_filename='dagmc.h5m'
+
+        h5m_filename = "dagmc.h5m"
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
             source=source,
             materials={
-                'center_column_shield_mat': 'Be',
-                'firstwall_mat': 'Be',
-                'blanket_mat': 'Be',
-                'divertor_mat': 'Be',
-                'supports_mat': 'Be',
-                'blanket_rear_wall_mat': 'Be',
-                'inboard_tf_coils_mat': 'Be'
+                "center_column_shield_mat": "Be",
+                "firstwall_mat": "Be",
+                "blanket_mat": "Be",
+                "divertor_mat": "Be",
+                "supports_mat": "Be",
+                "blanket_rear_wall_mat": "Be",
+                "inboard_tf_coils_mat": "Be",
             },
             simulation_batches=3,
-            simulation_particles_per_batch=2
+            simulation_particles_per_batch=2,
         )
 
-        bounding_box=my_model.find_bounding_box()
+        bounding_box = my_model.find_bounding_box()
 
         assert len(bounding_box) == 2
         assert len(bounding_box[0]) == 3

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -142,7 +142,7 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
             source=self.source,
-            materials={"test_shape": "Be"},
+            materials={"test_shape_2": "Be"},
             simulation_batches=3,
             simulation_particles_per_batch=2,
         )
@@ -169,7 +169,7 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
             source=self.source,
-            materials={"test_shape": "Be"},
+            materials={"test_shape_3": "Be"},
             simulation_batches=3,
             simulation_particles_per_batch=2,
         )

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -1,4 +1,3 @@
-
 import os
 import unittest
 from pathlib import Path
@@ -20,9 +19,10 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
                 (60, 70, "spline"),
                 (70, 50, "circle"),
                 (60, 25, "circle"),
-                (70, 0, "straight")],
+                (70, 0, "straight"),
+            ],
             distance=50,
-            material_tag='test_shape'
+            material_tag="test_shape",
         )
 
         self.test_shape_2 = paramak.CenterColumnShieldCylinder(
@@ -30,7 +30,7 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
             outer_radius=100,
             height=300,
             rotation_angle=360,
-            material_tag = 'test_shape_2',
+            material_tag="test_shape_2",
         )
 
         self.test_shape_3 = paramak.CenterColumnShieldCylinder(
@@ -38,8 +38,8 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
             outer_radius=100,
             height=300,
             rotation_angle=360,
-            center_height = 625,
-            material_tag = 'test_shape_3',
+            center_height=625,
+            material_tag="test_shape_3",
         )
 
         # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
@@ -51,49 +51,53 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
 
     def test_export_h5m_creates_file(self):
         """Tests the Shape.export_h5m method results in an outputfile."""
-        os.system('rm test_shape.h5m')
-        self.test_shape.export_h5m(filename='test_shape.h5m')
+        os.system("rm test_shape.h5m")
+        self.test_shape.export_h5m(filename="test_shape.h5m")
         assert Path("test_shape.h5m").exists() is True
 
     def test_export_h5m_creates_file_even_without_extention(self):
         """Tests the Shape.export_h5m method results in an outputfile even
         when the filename does not include the .h5m"""
-        os.system('rm test_shape.h5m')
-        self.test_shape.export_h5m(filename='test_shape')
+        os.system("rm test_shape.h5m")
+        self.test_shape.export_h5m(filename="test_shape")
         assert Path("test_shape.h5m").exists() is True
 
     def test_export_h5m_with_pymoab_accepts_include_graveyard(self):
-        os.system('rm test_shape.h5m')
+        os.system("rm test_shape.h5m")
         self.test_shape.export_h5m_with_pymoab(
-            filename='test_shape.h5m',
-            include_graveyard=True)
-        assert Path('test_shape.h5m').is_file
+            filename="test_shape.h5m", include_graveyard=True
+        )
+        assert Path("test_shape.h5m").is_file
         assert Path(self.test_shape.stl_filename).is_file
-        assert Path('graveyard.stl').is_file
+        assert Path("graveyard.stl").is_file
 
     def test_tolerance_increases_filesize(self):
-        os.system('rm test_shape.h5m')
+        os.system("rm test_shape.h5m")
         self.test_shape.export_h5m(
-            filename='test_shape_0001.h5m',
-            faceting_tolerance=0.001)
+            filename="test_shape_0001.h5m", faceting_tolerance=0.001
+        )
         self.test_shape.export_h5m(
-            filename='test_shape_001.h5m',
-            faceting_tolerance=0.01)
-        assert Path('test_shape_0001.h5m').stat().st_size > Path(
-            'test_shape_001.h5m').stat().st_size
+            filename="test_shape_001.h5m", faceting_tolerance=0.01
+        )
+        assert (
+            Path("test_shape_0001.h5m").stat().st_size
+            > Path("test_shape_001.h5m").stat().st_size
+        )
 
     def test_skipping_graveyard_decreases_filesize(self):
-        os.system('rm test_shape.h5m')
+        os.system("rm test_shape.h5m")
         self.test_shape.export_h5m_with_pymoab(
-            filename='skiped.h5m', include_graveyard=False)
+            filename="skiped.h5m", include_graveyard=False
+        )
         self.test_shape.export_h5m_with_pymoab(
-            filename='not_skipped.h5m',
-            include_graveyard=True)
-        assert Path('not_skipped.h5m').stat().st_size > Path(
-            'skiped.h5m').stat().st_size
+            filename="not_skipped.h5m", include_graveyard=True
+        )
+        assert (
+            Path("not_skipped.h5m").stat().st_size > Path("skiped.h5m").stat().st_size
+        )
 
     def test_graveyard_offset_increases_voulme(self):
-        os.system('rm test_shape.h5m')
+        os.system("rm test_shape.h5m")
         self.test_shape.graveyard_size = None
         self.test_shape.make_graveyard(graveyard_offset=100)
         small_offset = self.test_shape.graveyard.volume
@@ -104,20 +108,19 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
     def test_bounding_box_size(self):
 
         h5m_filename = self.test_shape.export_h5m_with_pymoab(
-            include_graveyard=False,
-            faceting_tolerance=1e-1
+            include_graveyard=False, faceting_tolerance=1e-1
         )
-                
-        h5m_filename='dagmc.h5m'
+
+        h5m_filename = "dagmc.h5m"
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
             source=self.source,
-            materials={'test_shape': 'Be'},
+            materials={"test_shape": "Be"},
             simulation_batches=3,
-            simulation_particles_per_batch=2
+            simulation_particles_per_batch=2,
         )
 
-        bounding_box=my_model.find_bounding_box()
+        bounding_box = my_model.find_bounding_box()
 
         assert len(bounding_box) == 2
         assert len(bounding_box[0]) == 3
@@ -129,24 +132,22 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
         assert bounding_box[1][1] == pytest.approx(25, abs=0.1)
         assert bounding_box[1][2] == pytest.approx(70, abs=0.1)
 
-
     def test_bounding_box_size_2(self):
 
         h5m_filename = self.test_shape_2.export_h5m_with_pymoab(
-            include_graveyard=False,
-            faceting_tolerance=1e-1
+            include_graveyard=False, faceting_tolerance=1e-1
         )
-                
-        h5m_filename='dagmc.h5m'
+
+        h5m_filename = "dagmc.h5m"
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
             source=self.source,
-            materials={'test_shape': 'Be'},
+            materials={"test_shape": "Be"},
             simulation_batches=3,
-            simulation_particles_per_batch=2
+            simulation_particles_per_batch=2,
         )
 
-        bounding_box=my_model.find_bounding_box()
+        bounding_box = my_model.find_bounding_box()
 
         assert len(bounding_box) == 2
         assert len(bounding_box[0]) == 3
@@ -161,20 +162,19 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
     def test_bounding_box_size_3(self):
 
         h5m_filename = self.test_shape_2.export_h5m_with_pymoab(
-            include_graveyard=False,
-            faceting_tolerance=1e-1
+            include_graveyard=False, faceting_tolerance=1e-1
         )
-                
-        h5m_filename='dagmc.h5m'
+
+        h5m_filename = "dagmc.h5m"
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
             source=self.source,
-            materials={'test_shape': 'Be'},
+            materials={"test_shape": "Be"},
             simulation_batches=3,
-            simulation_particles_per_batch=2
+            simulation_particles_per_batch=2,
         )
 
-        bounding_box=my_model.find_bounding_box()
+        bounding_box = my_model.find_bounding_box()
 
         assert len(bounding_box) == 2
         assert len(bounding_box[0]) == 3
@@ -185,19 +185,15 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
         assert bounding_box[1][0] == pytest.approx(100, abs=0.1)
         assert bounding_box[1][1] == pytest.approx(100, abs=0.1)
         assert bounding_box[1][2] == pytest.approx(775, abs=0.1)
+
+
 class TestSimulationResultsVsCsg(unittest.TestCase):
     """Makes a geometry in the paramak and in CSG geometry, simulates and
     compares the results"""
 
     def simulate_cylinder_cask_csg(
-            self,
-            material,
-            source,
-            height,
-            outer_radius,
-            thickness,
-            batches,
-            particles):
+        self, material, source, height, outer_radius, thickness, batches, particles
+    ):
         """Makes a CSG cask geometry runs a simulation and returns the result"""
 
         mats = openmc.Materials([material])
@@ -209,9 +205,9 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
         outer_top = openmc.ZPlane(z0=(height * 0.5) + thickness)
         outer_bottom = openmc.ZPlane(z0=(-height * 0.5) - thickness)
 
-        sphere_1 = openmc.Sphere(r=100, boundary_type='vacuum')
+        sphere_1 = openmc.Sphere(r=100, boundary_type="vacuum")
 
-        cylinder_region = -outer_cylinder & +inner_cylinder & -inner_top & + inner_bottom
+        cylinder_region = -outer_cylinder & +inner_cylinder & -inner_top & +inner_bottom
         cylinder_cell = openmc.Cell(region=cylinder_region)
         cylinder_cell.fill = material
 
@@ -236,10 +232,15 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
             & ~inner_void_region
         )
 
-        universe = openmc.Universe(cells=[
-            inner_void_cell, cylinder_cell, top_cap_cell,
-            bottom_cap_cell, sphere_1_cell
-        ])
+        universe = openmc.Universe(
+            cells=[
+                inner_void_cell,
+                cylinder_cell,
+                top_cap_cell,
+                bottom_cap_cell,
+                sphere_1_cell,
+            ]
+        )
 
         geom = openmc.Geometry(universe)
 
@@ -248,18 +249,15 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
         sett.batches = batches
         sett.particles = particles
         sett.inactive = 0
-        sett.run_mode = 'fixed source'
+        sett.run_mode = "fixed source"
         sett.photon_transport = True
         sett.source = source
 
-        cell_filter = openmc.CellFilter([
-            cylinder_cell,
-            top_cap_cell,
-            bottom_cap_cell])
+        cell_filter = openmc.CellFilter([cylinder_cell, top_cap_cell, bottom_cap_cell])
 
-        tally = openmc.Tally(name='csg_heating')
+        tally = openmc.Tally(name="csg_heating")
         tally.filters = [cell_filter]
-        tally.scores = ['heating']
+        tally.scores = ["heating"]
         tallies = openmc.Tallies()
         tallies.append(tally)
 
@@ -270,25 +268,19 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
         results = openmc.StatePoint(sp_filename)
 
         # access the tally using pandas dataframes
-        tally = results.get_tally(name='csg_heating')
+        tally = results.get_tally(name="csg_heating")
         tally_df = tally.get_pandas_dataframe()
 
-        return tally_df['mean'].sum()
+        return tally_df["mean"].sum()
 
     def simulate_cylinder_cask_cad(
-            self,
-            material,
-            source,
-            height,
-            outer_radius,
-            thickness,
-            batches,
-            particles):
+        self, material, source, height, outer_radius, thickness, batches, particles
+    ):
         """Makes a CAD cask geometry runs a simulation and returns the result"""
 
         top_cap_cell = paramak.RotateStraightShape(
-            stp_filename='top_cap_cell.stp',
-            material_tag='test_mat',
+            stp_filename="top_cap_cell.stp",
+            material_tag="test_mat",
             points=[
                 (outer_radius, height * 0.5),
                 (outer_radius, (height * 0.5) + thickness),
@@ -298,29 +290,26 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
         )
 
         bottom_cap_cell = paramak.RotateStraightShape(
-            stp_filename='bottom_cap_cell.stp',
-            material_tag='test_mat',
+            stp_filename="bottom_cap_cell.stp",
+            material_tag="test_mat",
             points=[
                 (outer_radius, -height * 0.5),
                 (outer_radius, (-height * 0.5) - thickness),
                 (0, (-height * 0.5) - thickness),
                 (0, -height * 0.5),
-            ]
+            ],
         )
 
         cylinder_cell = paramak.CenterColumnShieldCylinder(
             height=height,
             inner_radius=outer_radius - thickness,
             outer_radius=outer_radius,
-            material_tag='test_mat',
+            material_tag="test_mat",
         )
 
         my_geometry = paramak.Reactor(
-            shapes_and_components=[
-                cylinder_cell,
-                bottom_cap_cell, top_cap_cell
-            ],
-            method='pymoab'
+            shapes_and_components=[cylinder_cell, bottom_cap_cell, top_cap_cell],
+            method="pymoab",
         )
 
         my_model = paramak_neutronics.NeutronicsModel(
@@ -328,14 +317,17 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
             source=source,
             simulation_batches=batches,
             simulation_particles_per_batch=particles,
-            materials={'test_mat': material},
-            cell_tallies=['heating'],
+            materials={"test_mat": material},
+            cell_tallies=["heating"],
         )
 
         my_model.simulate()
 
         # scaled from MeV to eV
-        return my_model.results['test_mat_heating']['MeV per source particle']['result'] * 1e6
+        return (
+            my_model.results["test_mat_heating"]["MeV per source particle"]["result"]
+            * 1e6
+        )
 
     def test_cylinder_cask(self):
         """Runs the same source and material with CAD and CSG geoemtry"""
@@ -347,10 +339,10 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
         batches = 10
         particles = 500
 
-        test_material = openmc.Material(name='test_material')
-        test_material.set_density('g/cm3', 7.75)
-        test_material.add_element('Fe', 0.95, percent_type='wo')
-        test_material.add_element('C', 0.05, percent_type='wo')
+        test_material = openmc.Material(name="test_material")
+        test_material.set_density("g/cm3", 7.75)
+        test_material.add_element("Fe", 0.95, percent_type="wo")
+        test_material.add_element("C", 0.05, percent_type="wo")
 
         source = openmc.Source()
         source.space = openmc.stats.Point((0, 0, 0))
@@ -358,10 +350,12 @@ class TestSimulationResultsVsCsg(unittest.TestCase):
         source.energy = openmc.stats.Discrete([14e6], [1.0])
 
         csg_result = self.simulate_cylinder_cask_csg(
-            test_material, source, height, outer_radius, thickness, batches, particles)
+            test_material, source, height, outer_radius, thickness, batches, particles
+        )
 
         cad_result = self.simulate_cylinder_cask_cad(
-            test_material, source, height, outer_radius, thickness, batches, particles)
+            test_material, source, height, outer_radius, thickness, batches, particles
+        )
 
         assert pytest.approx(csg_result, rel=0.02) == cad_result
 

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -181,7 +181,7 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
         assert len(bounding_box[1]) == 3
         assert bounding_box[0][0] == pytest.approx(-100, abs=0.1)
         assert bounding_box[0][1] == pytest.approx(-100, abs=0.1)
-        assert bounding_box[0][2] == pytest.approx(-475, abs=0.1)
+        assert bounding_box[0][2] == pytest.approx(475, abs=0.1)
         assert bounding_box[1][0] == pytest.approx(100, abs=0.1)
         assert bounding_box[1][1] == pytest.approx(100, abs=0.1)
         assert bounding_box[1][2] == pytest.approx(775, abs=0.1)

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -25,6 +25,30 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
             material_tag='test_shape'
         )
 
+        self.test_shape_2 = paramak.CenterColumnShieldCylinder(
+            inner_radius=80,
+            outer_radius=100,
+            height=300,
+            rotation_angle=360,
+            material_tag = 'test_shape_2',
+        )
+
+        self.test_shape_3 = paramak.CenterColumnShieldCylinder(
+            inner_radius=80,
+            outer_radius=100,
+            height=300,
+            rotation_angle=360,
+            center_height = 625,
+            material_tag = 'test_shape_3',
+        )
+
+        # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
+        # directions and 14MeV neutrons
+        self.source = openmc.Source()
+        self.source.space = openmc.stats.Point((0, 0, 0))
+        self.source.angle = openmc.stats.Isotropic()
+        self.source.energy = openmc.stats.Discrete([14e6], [1])
+
     def test_export_h5m_creates_file(self):
         """Tests the Shape.export_h5m method results in an outputfile."""
         os.system('rm test_shape.h5m')
@@ -83,18 +107,11 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
             include_graveyard=False,
             faceting_tolerance=1e-1
         )
-
-        # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
-        # directions and 14MeV neutrons
-        source = openmc.Source()
-        source.space = openmc.stats.Point((0, 0, 0))
-        source.angle = openmc.stats.Isotropic()
-        source.energy = openmc.stats.Discrete([14e6], [1])
                 
         h5m_filename='dagmc.h5m'
         my_model = paramak_neutronics.NeutronicsModel(
             h5m_filename=h5m_filename,
-            source=source,
+            source=self.source,
             materials={'test_shape': 'Be'},
             simulation_batches=3,
             simulation_particles_per_batch=2
@@ -113,6 +130,61 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
         assert bounding_box[1][2] == pytest.approx(70, abs=0.1)
 
 
+    def test_bounding_box_size_2(self):
+
+        h5m_filename = self.test_shape_2.export_h5m_with_pymoab(
+            include_graveyard=False,
+            faceting_tolerance=1e-1
+        )
+                
+        h5m_filename='dagmc.h5m'
+        my_model = paramak_neutronics.NeutronicsModel(
+            h5m_filename=h5m_filename,
+            source=self.source,
+            materials={'test_shape': 'Be'},
+            simulation_batches=3,
+            simulation_particles_per_batch=2
+        )
+
+        bounding_box=my_model.find_bounding_box()
+
+        assert len(bounding_box) == 2
+        assert len(bounding_box[0]) == 3
+        assert len(bounding_box[1]) == 3
+        assert bounding_box[0][0] == pytest.approx(-100, abs=0.1)
+        assert bounding_box[0][1] == pytest.approx(-100, abs=0.1)
+        assert bounding_box[0][2] == pytest.approx(-150, abs=0.1)
+        assert bounding_box[1][0] == pytest.approx(100, abs=0.1)
+        assert bounding_box[1][1] == pytest.approx(100, abs=0.1)
+        assert bounding_box[1][2] == pytest.approx(150, abs=0.1)
+
+    def test_bounding_box_size_3(self):
+
+        h5m_filename = self.test_shape_2.export_h5m_with_pymoab(
+            include_graveyard=False,
+            faceting_tolerance=1e-1
+        )
+                
+        h5m_filename='dagmc.h5m'
+        my_model = paramak_neutronics.NeutronicsModel(
+            h5m_filename=h5m_filename,
+            source=self.source,
+            materials={'test_shape': 'Be'},
+            simulation_batches=3,
+            simulation_particles_per_batch=2
+        )
+
+        bounding_box=my_model.find_bounding_box()
+
+        assert len(bounding_box) == 2
+        assert len(bounding_box[0]) == 3
+        assert len(bounding_box[1]) == 3
+        assert bounding_box[0][0] == pytest.approx(-100, abs=0.1)
+        assert bounding_box[0][1] == pytest.approx(-100, abs=0.1)
+        assert bounding_box[0][2] == pytest.approx(-475, abs=0.1)
+        assert bounding_box[1][0] == pytest.approx(100, abs=0.1)
+        assert bounding_box[1][1] == pytest.approx(100, abs=0.1)
+        assert bounding_box[1][2] == pytest.approx(775, abs=0.1)
 class TestSimulationResultsVsCsg(unittest.TestCase):
     """Makes a geometry in the paramak and in CSG geometry, simulates and
     compares the results"""

--- a/tests/test_shape_neutronics.py
+++ b/tests/test_shape_neutronics.py
@@ -161,7 +161,7 @@ class TestObjectNeutronicsArguments(unittest.TestCase):
 
     def test_bounding_box_size_3(self):
 
-        h5m_filename = self.test_shape_2.export_h5m_with_pymoab(
+        h5m_filename = self.test_shape_3.export_h5m_with_pymoab(
             include_graveyard=False, faceting_tolerance=1e-1
         )
 


### PR DESCRIPTION
This PR makes use of the new bounding_box attribute to set the mesh corners in the event that mesh corners are not specifically set. This has the benefit of ensuring your mesh covers the geometry.

Previously it was difficult to center the mesh and ensure the mesh overlays the whole geometry

The dagmc geometry bounding_box can be found with the previously adde ```find_bounding_box``` method. For the time being this includes the graveyard but that will soon be changed on DAGMC develop branch.
